### PR TITLE
Update installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone --recurse-submodules git@github.com:FreeRTOS/Lab-Project-FreeRTOS-LoRa
 
 ```
 cd Lab-Project-FreeRTOS-LoRaWAN
-git apply  FreeRTOS-LoRaMac-node-v4_4_4.patch
+git apply --whitespace=fix FreeRTOS-LoRaMac-node-v4_4_4.patch
 ```
 
 ## Setting up IDE and Project


### PR DESCRIPTION
The installation instructions in README.md did not work on windows
systems - there were whitespace differences in the code that caused
the git apply command to not work.

The fix was done by changing the git command to include whitespace
option as fix, which causes the installation to work on Windows systems
and doesn't affect the installation in Posix systems.

Fixes #4 