### PR TITLE
Add FreeRTOS Labs project notice to SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,14 @@
+## FreeRTOS Labs project
+
+This repository is a **FreeRTOS Labs** project. As described on the
+[FreeRTOS Labs introduction page](https://www.freertos.org/Documentation/03-Libraries/05-FreeRTOS-labs/01-Introduction),
+Labs projects are functional but may be incomplete, experimental, or provided primarily for
+open-source community interest. They are **not** part of the actively maintained, released
+FreeRTOS libraries. Please consider the limitations described on the Labs page before
+concluding that an observed behavior is a security vulnerability.
+
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security
+via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com.
+Please do **not** create a public github issue.


### PR DESCRIPTION
This adds a short notice to `.github/SECURITY.md` clarifying that this repository is a **FreeRTOS Labs** project and linking to the [FreeRTOS Labs introduction page](https://www.freertos.org/Documentation/03-Libraries/05-FreeRTOS-labs/01-Introduction).

Labs projects are functional but may be incomplete or experimental and are not part of the actively maintained, released FreeRTOS libraries. The notice asks reporters to consider those documented Labs limitations before concluding that an observed behavior is an issue in a released library, while keeping the standard AWS/Amazon reporting channel intact.

This file previously had no SECURITY.md; the PR also adds the standard reporting section.